### PR TITLE
Add a link to react-use-redux-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Hooks are really new, and we are just beginning to see what people do with them.
 - [`use-substate`](https://github.com/philipp-spiess/use-substate)
 - [`react-use-redux`](https://github.com/martynaskadisa/react-use-redux)
 - [`react-use-dux`](https://github.com/richardpj/react-use-dux)
+- [`react-use-redux-state`](https://github.com/pinyin/react-use-redux-state)
 
 ## Thanks
 


### PR DESCRIPTION
Hi,

I've created a [super simple solution](https://github.com/pinyin/react-use-redux-state), and wondering if it's appropriate to ask for a link from here.

The idea is to give up all control on state structure and to leave structuring & diffing logic to the user, while still providing some minimal helpers to construct actions.

I see the idea is very different from what `react-redux` did in the past and may not be suitable to be listed here, so please don't hesitate to close this PR if that's the problem.

Thanks for reading.