### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"


### PR DESCRIPTION
Fixes #15.

Without the `types` field, some IDEs (at least IntelliJ IDEA) would not find the TypeScript types.