### PR TITLE
Move react-scripts and types/node to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",
+    "@types/node": "^10.12.12",
     "@types/react": "^16.7.13",
     "@types/react-dom": "^16.0.11",
     "babel-core": "^6.26.3",
@@ -44,6 +45,7 @@
     "prettier": "^1.14.3",
     "react": "^16.7.0-alpha.2",
     "react-dom": "^16.7.0-alpha.2",
+    "react-scripts": "^2.1.1",
     "redux": "^4.0.1",
     "rollup": "^0.66.6",
     "rollup-plugin-babel": "^4.0.3",
@@ -57,9 +59,5 @@
   },
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "@types/node": "^10.12.12",
-    "react-scripts": "^2.1.1"
-  }
+  ]
 }


### PR DESCRIPTION
I was having issues installing this as a dependency on certain devservers with older versions of node, since `react-scripts` depends on a lot of stuff.

```
$ yarn add redux-react-hook
yarn add v1.9.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "linux" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.0.17: The platform "linux" is incompatible with this module.
info "fsevents@1.0.17" is an optional dependency and failed compatibility check. Excluding it from installation.
error eslint@5.6.0: The engine "node" is incompatible with this module. Expected version "^6.14.0 || ^8.10.0 || >=9.10.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

$ node -v
v8.9.0
```