### PR TITLE
Avoid double render if new mapState returns same mappedState

### DIFF
--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -249,6 +249,21 @@ describe('redux-react-hook', () => {
 
       expect(getText()).toBe('0');
     });
+
+    it('renders once if new mapState returns same mappedState', () => {
+      let renderCount = 0;
+      const Component = ({prop}: {prop: any}) => {
+        renderCount++;
+        const mapState = React.useCallback((s: any) => s, [prop]);
+        useMappedState(mapState);
+        return null;
+      };
+
+      render(<Component prop={1} />);
+      render(<Component prop={2} />);
+
+      expect(renderCount).toBe(2);
+    });
   });
 
   describe('useDispatch', () => {
@@ -268,7 +283,7 @@ describe('redux-react-hook', () => {
   });
 
   describe('create', () => {
-    it('returnsa new context and functions each time', () => {
+    it('returns a new context and functions each time', () => {
       const first = create();
       const second = create();
       expect(first.StoreContext).not.toBe(second.StoreContext);

--- a/src/create.ts
+++ b/src/create.ts
@@ -42,15 +42,13 @@ export function create<
     if (!store) {
       throw new Error(CONTEXT_ERROR_MESSAGE);
     }
-    const mapStateFactory = () => mapState;
     const runMapState = () => mapState(store.getState());
 
     const [derivedState, setDerivedState] = useState(runMapState);
 
     // If the store or mapState change, rerun mapState
-    const [prevStore, setPrevStore] = useState(store);
-    const [prevMapState, setPrevMapState] = useState(mapStateFactory);
-
+    const lastStore = useRef(store);
+    const lastMapState = useRef(mapState);
     // We keep lastDerivedState in a ref and update it imperatively
     // after calling setDerivedState so it's always up-to-date.
     // We can't update it in useEffect because state might be updated
@@ -65,9 +63,9 @@ export function create<
       }
     };
 
-    if (prevStore !== store || prevMapState !== mapState) {
-      setPrevStore(store);
-      setPrevMapState(mapStateFactory);
+    if (lastStore.current !== store || lastMapState.current !== mapState) {
+      lastStore.current = store;
+      lastMapState.current = mapState;
       wrappedSetDerivedState();
     }
 


### PR DESCRIPTION
This PR is based on https://github.com/facebookincubator/redux-react-hook/pull/24. 

Storing new `mapState` and `store` in refs will prevent a double render if the actual `mappedState` is equal to the previous one. 