### PR TITLE
Simplify the implementation

### DIFF
--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -45,12 +45,18 @@ describe('redux-react-hook', () => {
     document.body.removeChild(reactRoot);
   });
 
-  function render(element: React.ReactElement<any>) {
+  function render(
+    element: React.ReactElement<any>,
+    options?: {dontFlushEffects?: boolean},
+  ) {
     ReactDOM.render(
       <StoreContext.Provider value={store}>{element}</StoreContext.Provider>,
       reactRoot,
     );
-    flushEffects();
+
+    if (!options || !options.dontFlushEffects) {
+      flushEffects();
+    }
   }
 
   function getText() {
@@ -161,10 +167,12 @@ describe('redux-react-hook', () => {
       return <div>{foo}</div>;
     };
 
-    render(<Component />);
+    render(<Component />, {dontFlushEffects: true});
 
     state = {...state, foo: 'foo'};
     subscriberCallback();
+
+    flushEffects();
 
     expect(getText()).toBe('foo');
   });

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -50,6 +50,7 @@ describe('redux-react-hook', () => {
       <StoreContext.Provider value={store}>{element}</StoreContext.Provider>,
       reactRoot,
     );
+    flushEffects();
   }
 
   function getText() {
@@ -165,9 +166,6 @@ describe('redux-react-hook', () => {
     state = {...state, foo: 'foo'};
     subscriberCallback();
 
-    // run the useEffect that subscribes to the store
-    flushEffects();
-
     expect(getText()).toBe('foo');
   });
 
@@ -180,8 +178,6 @@ describe('redux-react-hook', () => {
 
     render(<Component n={100} />);
     render(<Component n={45} />);
-
-    flushEffects();
 
     state = {...state, foo: 'foo'};
     subscriberCallback();
@@ -201,9 +197,6 @@ describe('redux-react-hook', () => {
     };
 
     render(<Component />);
-
-    flushEffects();
-
     ReactDOM.unmountComponentAtNode(reactRoot);
 
     const consoleErrorSpy = jest.spyOn(console, 'error');
@@ -232,8 +225,6 @@ describe('redux-react-hook', () => {
         <Component />
       </StoreContext.Provider>,
     );
-
-    flushEffects();
 
     store.dispatch({
       type: 'test',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import {createContext, useContext, useEffect, useRef, useState} from 'react';
+import {createContext, useContext, useEffect, useState} from 'react';
 import {Action, Dispatch, Store} from 'redux';
 import shallowEqual from './shallowEqual';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,14 @@ export function useMappedState<TState, TResult>(
   mapState: (state: TState) => TResult,
 ): TResult {
   const store = useContext(StoreContext);
-  const [derivedState, setDerivedState] = useState(() =>
-    mapState(store.getState()),
-  );
+
   if (!store) {
     throw new Error(CONTEXT_ERROR_MESSAGE);
   }
+
+  const [derivedState, setDerivedState] = useState(() =>
+    mapState(store.getState()),
+  );
 
   useEffect(
     () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,14 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "jsx": "preserve",
-    "lib": ["es6", "dom", "es2016", "es2017"],
+    "lib": [
+      "es6",
+      "dom",
+      "es2016",
+      "es2017"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
@@ -25,6 +30,14 @@
     "suppressImplicitAnyIndexErrors": true,
     "target": "es5"
   },
-  "exclude": ["build", "dist", "example", "node_modules", "rollup.config.js"],
-  "include": ["src"]
+  "exclude": [
+    "build",
+    "dist",
+    "example",
+    "node_modules",
+    "rollup.config.js"
+  ],
+  "include": [
+    "src"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,9 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "jsx": "preserve",
-    "lib": [
-      "es6",
-      "dom",
-      "es2016",
-      "es2017"
-    ],
+    "lib": ["es6", "dom", "es2016", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
@@ -30,14 +25,6 @@
     "suppressImplicitAnyIndexErrors": true,
     "target": "es5"
   },
-  "exclude": [
-    "build",
-    "dist",
-    "example",
-    "node_modules",
-    "rollup.config.js"
-  ],
-  "include": [
-    "src"
-  ]
+  "exclude": ["build", "dist", "example", "node_modules", "rollup.config.js"],
+  "include": ["src"]
 }


### PR DESCRIPTION
**Tests pass with React master (and the upcoming stable release).** The "don't re-render too often" test doesn't pass with React alphas because the new bailout behavior wasn't released yet.

This seems like the idiomatic solution?