### PR TITLE
Allowing use of memoization array.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,6 @@ export function useMappedState<TState, TResult>(
 
   const [derivedState, setDerivedState] = useState(runMapState);
 
-  // If the store or mapState change, rerun mapState
-  const [prevStore, setPrevStore] = useState(store);
-  const [prevMapState, setPrevMapState] = useState(mapStateFactory);
-
   // We keep lastDerivedState in a ref and update it imperatively
   // after calling setDerivedState so it's always up-to-date.
   // We can't update it in useEffect because state might be updated
@@ -51,12 +47,6 @@ export function useMappedState<TState, TResult>(
       lastDerivedState.current = newDerivedState;
     }
   };
-
-  if (prevStore !== store || prevMapState !== mapState) {
-    setPrevStore(store);
-    setPrevMapState(mapStateFactory);
-    wrappedSetDerivedState();
-  }
 
   useEffect(
     () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ const CONTEXT_ERROR_MESSAGE =
  */
 export function useMappedState<TState, TResult>(
   mapState: (state: TState) => TResult,
+  memoizationArray: Array<any> = [mapState],
 ): TResult {
   const store = useContext(StoreContext);
   if (!store) {
@@ -87,7 +88,7 @@ export function useMappedState<TState, TResult>(
         unsubscribe();
       };
     },
-    [store, mapState],
+    [store, ...memoizationArray],
   );
 
   return derivedState;


### PR DESCRIPTION
As explained in #30 

Hooks usually accept a second argument of values to memoize over. In that respect, the `useMappedState` is a little weird in that it accepts the mapper function to be pre-memoized or defined as a constant outside of the component.

Accepting an argument of values to memoize based on removes the need to do that.

By defaulting to reference to the mapper function, we get existing semantics when no second argument is provided and the change is backwards compatible.