### PR TITLE
Add useBoundActionCreators function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - [`StoreContext`](#storecontext)
   - [`useMappedState(mapState)`](#usemappedstatemapstate)
   - [`useDispatch()`](#usedispatch)
-  - [`useMappedDispatch(mapDispatch)`](#usemappeddispatchmapdispatch)
+  - [`useBoundActionCreators(mapDispatch)`](#useboundactioncreatorsmapdispatch)
 - [Example](#example)
 - [FAQ](#faq)
 - [More info](#more-info)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [`StoreContext`](#storecontext)
   - [`useMappedState(mapState)`](#usemappedstatemapstate)
   - [`useDispatch()`](#usedispatch)
+  - [`useMappedDispatch(mapDispatch)`](#usemappeddispatchmapdispatch)
 - [Example](#example)
 - [FAQ](#faq)
 - [More info](#more-info)
@@ -169,6 +170,28 @@ function DeleteButton({index}) {
   return <button onClick={deleteTodo}>x</button>;
 }
 ```
+
+### `useBoundActionCreators(actionCreators)`
+
+Given a plain JavaScript object with action creators as values, returns an object with the same keys as the input object with functions that dispatch actions created with the original action creators into the store.
+
+```tsx
+import {useBoundActionCreators} from 'redux-react-hook';
+import {refresh, otherAction} from './actions';
+
+function DeleteButton({index}) {
+  const {refresh, otherAction} = useBoundActionCreators({refresh, otherAction});
+
+  return (
+    <>
+      <button onClick={refresh}>x</button>
+      <button onClick={otherAction}>y</button>
+    </>
+  );
+}
+```
+
+This essentially combines `useDispatch` and `useCallback` into one hook which can bind many action creators all at once.
 
 ### `create()`
 

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -4,7 +4,13 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {act} from 'react-dom/test-utils';
 import {Store, createStore as createReduxStore} from 'redux';
-import {StoreContext, create, useDispatch, useMappedState} from '..';
+import {
+  StoreContext,
+  create,
+  useBoundActionCreators,
+  useDispatch,
+  useMappedState,
+} from '..';
 
 interface IAction {
   type: 'add todo';
@@ -306,6 +312,47 @@ describe('redux-react-hook', () => {
       act(() => {
         ReactDOM.render(<Component />, reactRoot);
       });
+    });
+  });
+
+  describe('useBoundActionCreators', () => {
+    it('calls store dispatch', () => {
+      const ac1 = (arg: string) => arg;
+      const ac2 = (a: number, b: number) => ({a, b});
+      const Component = () => {
+        const dispatch = useBoundActionCreators({ac1, ac2});
+        React.useEffect(() => {
+          dispatch.ac1('foo');
+          dispatch.ac2(3, 4);
+        });
+        return null;
+      };
+
+      render(<Component />);
+
+      expect(store.dispatch).toHaveBeenCalledTimes(2);
+      expect(store.dispatch).toHaveBeenCalledWith('foo');
+      expect(store.dispatch).toHaveBeenLastCalledWith({a: 3, b: 4});
+    });
+
+    it('calls store dispatch (inline action creators)', () => {
+      const Component = () => {
+        const dispatch = useBoundActionCreators({
+          ac1: (arg: string) => arg,
+          ac2: (a: number, b: number) => ({a, b}),
+        });
+        React.useEffect(() => {
+          dispatch.ac1('foo');
+          dispatch.ac2(3, 4);
+        });
+        return null;
+      };
+
+      render(<Component />);
+
+      expect(store.dispatch).toHaveBeenCalledTimes(2);
+      expect(store.dispatch).toHaveBeenCalledWith('foo');
+      expect(store.dispatch).toHaveBeenLastCalledWith({a: 3, b: 4});
     });
   });
 

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -319,20 +319,23 @@ describe('redux-react-hook', () => {
     it('calls store dispatch', () => {
       const ac1 = (arg: string) => arg;
       const ac2 = (a: number, b: number) => ({a, b});
+      const ac3 = () => 'ac3';
       const Component = () => {
-        const dispatch = useBoundActionCreators({ac1, ac2});
+        const dispatch = useBoundActionCreators({ac1, ac2, ac3});
         React.useEffect(() => {
           dispatch.ac1('foo');
           dispatch.ac2(3, 4);
+          dispatch.ac3();
         });
         return null;
       };
 
       render(<Component />);
 
-      expect(store.dispatch).toHaveBeenCalledTimes(2);
+      expect(store.dispatch).toHaveBeenCalledTimes(3);
       expect(store.dispatch).toHaveBeenCalledWith('foo');
-      expect(store.dispatch).toHaveBeenLastCalledWith({a: 3, b: 4});
+      expect(store.dispatch).toHaveBeenCalledWith({a: 3, b: 4});
+      expect(store.dispatch).toHaveBeenLastCalledWith('ac3');
     });
 
     it('calls store dispatch (inline action creators)', () => {
@@ -340,19 +343,21 @@ describe('redux-react-hook', () => {
         const dispatch = useBoundActionCreators({
           ac1: (arg: string) => arg,
           ac2: (a: number, b: number) => ({a, b}),
+          ac3: () => 'ac3',
         });
         React.useEffect(() => {
           dispatch.ac1('foo');
           dispatch.ac2(3, 4);
+          dispatch.ac3();
         });
         return null;
       };
 
       render(<Component />);
 
-      expect(store.dispatch).toHaveBeenCalledTimes(2);
-      expect(store.dispatch).toHaveBeenCalledWith('foo');
-      expect(store.dispatch).toHaveBeenLastCalledWith({a: 3, b: 4});
+      expect(store.dispatch).toHaveBeenCalledTimes(3);
+      expect(store.dispatch).toHaveBeenCalledWith({a: 3, b: 4});
+      expect(store.dispatch).toHaveBeenLastCalledWith('ac3');
     });
   });
 

--- a/src/create.ts
+++ b/src/create.ts
@@ -128,10 +128,10 @@ export function create<
   ): DispatchMap<T> => {
     const dispatch = useDispatch();
     const map: {[key: string]: Function} = {};
-    for (const key in actions) {
+    Object.keys(actions).forEach((key) => {
       const ac = actions[key];
       map[key] = (...args: InferArgs<typeof ac>) => dispatch(ac(...args));
-    }
+    });
     return map as DispatchMap<T>;
   };
 

--- a/src/create.ts
+++ b/src/create.ts
@@ -4,7 +4,11 @@ import {createContext, useContext, useEffect, useRef, useState} from 'react';
 import {Action, ActionCreatorsMapObject, Dispatch, Store} from 'redux';
 import shallowEqual from './shallowEqual';
 
-type InferArgs<F> = F extends (...args: infer T) => unknown ? T : never;
+type InferArgs<F> = F extends () => unknown
+  ? never[]
+  : F extends (...args: infer T) => unknown
+    ? T
+    : never;
 export type DispatchMap<T> = {
   [K in keyof T]: (...args: InferArgs<T[K]>) => void
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@
 
 import {create} from './create';
 
-export const {StoreContext, useDispatch, useMappedState} = create<
-  any,
-  any,
-  any
->();
+export const {
+  StoreContext,
+  useBoundActionCreators,
+  useDispatch,
+  useMappedState,
+} = create<any, any, any>();
 
 export {create};


### PR DESCRIPTION
This PR adds a ~~`useMappedDispatch`~~ `useBoundActionCreators` function which behaves a lot like the object-notation of the `mapDispatchToProps` argument for `connect` from `react-redux`.