### PR TITLE
Simple usemappedstate

### DIFF
--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -255,9 +255,7 @@ describe('redux-react-hook', () => {
       const Component = ({prop}: {prop: any}) => {
         const mapState = React.useCallback((s: IState) => s, [prop]);
         useMappedState(mapState);
-        React.useEffect(() => {
-          renderCount++;
-        });
+        renderCount++;
         return null;
       };
 
@@ -278,6 +276,24 @@ describe('redux-react-hook', () => {
       act(() => {
         ReactDOM.render(<Component />, reactRoot);
       });
+    });
+
+    it('does not provide stale mapped state', () => {
+      let flag = false;
+
+      const Component = ({prop}: {prop: any}) => {
+        const mapState = React.useCallback((s: IState) => s[prop], [prop]);
+        const mappedState = useMappedState(mapState);
+        if (state[prop] !== mappedState) {
+          flag = true;
+        }
+        return null;
+      };
+
+      render(<Component prop="foo" />);
+      render(<Component prop="bar" />);
+
+      expect(flag).toBe(false);
     });
   });
 

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -214,7 +214,7 @@ describe('redux-react-hook', () => {
       updateStore({...state, foo: 'foo'});
 
       // mapState is called during and after the first render
-      expect(mapStateCalls).toBe(2);
+      expect(mapStateCalls).toBe(1);
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
@@ -316,7 +316,40 @@ describe('redux-react-hook', () => {
       // mapState called twice on subscription:
       // 1. Pull data on initial render
       // 2. Pull data before right before subscribing in useEffect
-      expect(mapStateCalls).toBe(2);
+      expect(mapStateCalls).toBe(1);
+    });
+
+    it('memoizes mapState by default', () => {
+      let mapStateCallsMemoized = 0;
+
+      const ComponentMemoizeMapState = () => {
+        const mapState = React.useCallback((s: IState) => {
+          mapStateCallsMemoized++;
+          return s.foo;
+        }, []);
+        const foo = useMappedState(mapState);
+        return <div>{foo}</div>;
+      };
+
+      let mapStateCallsNotMemoized = 0;
+
+      const ComponentNotMemoizeMapState = () => {
+        const mapState = React.useCallback((s: IState) => {
+          mapStateCallsNotMemoized++;
+          return s.foo;
+        }, []);
+        const foo = useMappedState(mapState, false);
+        return <div>{foo}</div>;
+      };
+
+      render(<ComponentMemoizeMapState />);
+      render(<ComponentMemoizeMapState />);
+
+      render(<ComponentNotMemoizeMapState />);
+      render(<ComponentNotMemoizeMapState />);
+
+      expect(mapStateCallsMemoized).toBe(1);
+      expect(mapStateCallsNotMemoized).toBe(3);
     });
   });
 

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -318,39 +318,6 @@ describe('redux-react-hook', () => {
       // 2. Pull data before right before subscribing in useEffect
       expect(mapStateCalls).toBe(1);
     });
-
-    it('memoizes mapState by default', () => {
-      let mapStateCallsMemoized = 0;
-
-      const ComponentMemoizeMapState = () => {
-        const mapState = React.useCallback((s: IState) => {
-          mapStateCallsMemoized++;
-          return s.foo;
-        }, []);
-        const foo = useMappedState(mapState);
-        return <div>{foo}</div>;
-      };
-
-      let mapStateCallsNotMemoized = 0;
-
-      const ComponentNotMemoizeMapState = () => {
-        const mapState = React.useCallback((s: IState) => {
-          mapStateCallsNotMemoized++;
-          return s.foo;
-        }, []);
-        const foo = useMappedState(mapState, false);
-        return <div>{foo}</div>;
-      };
-
-      render(<ComponentMemoizeMapState />);
-      render(<ComponentMemoizeMapState />);
-
-      render(<ComponentNotMemoizeMapState />);
-      render(<ComponentNotMemoizeMapState />);
-
-      expect(mapStateCallsMemoized).toBe(1);
-      expect(mapStateCallsNotMemoized).toBe(3);
-    });
   });
 
   describe('useDispatch', () => {

--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -295,6 +295,29 @@ describe('redux-react-hook', () => {
 
       expect(flag).toBe(false);
     });
+
+    it("doesn't call mapState too often", () => {
+      let mapStateCalls = 0;
+
+      const Component = () => {
+        const mapState = React.useCallback((s: IState) => {
+          mapStateCalls++;
+          return s.foo;
+        }, []);
+        const foo = useMappedState(mapState);
+        return <div>{foo}</div>;
+      };
+
+      render(<Component />);
+      render(<Component />);
+      render(<Component />);
+      render(<Component />);
+
+      // mapState called twice on subscription:
+      // 1. Pull data on initial render
+      // 2. Pull data before right before subscribing in useEffect
+      expect(mapStateCalls).toBe(2);
+    });
   });
 
   describe('useDispatch', () => {

--- a/src/create.ts
+++ b/src/create.ts
@@ -82,6 +82,11 @@ export function create<
     // an update when derived state changes.
     const [, forceUpdate] = useReducer(x => x + 1, 0);
 
+    // Keep previously commited derived state in a ref.
+    // Compare it to the a one when an action is dispatched
+    // and call forceUpdate if they are different.
+    // We could rely on React's bail out it makes a component
+    // render which is not necessary in that case.
     const lastStateRef = useRef(derivedState);
 
     useEffect(() => {

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import {createContext, useContext, useEffect, useRef, useState} from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from 'react';
 import {Action, Dispatch, Store} from 'redux';
 import shallowEqual from './shallowEqual';
 
@@ -48,10 +55,11 @@ export function create<
       throw new MissingProviderError();
     }
 
-    const derivedState = mapState(store.getState());
+    const state = store.getState();
+    const derivedState = useMemo(() => mapState(state), [state, mapState]);
 
     if (process.env.NODE_ENV === 'development') {
-      const derivedStateCheck = mapState(store.getState());
+      const derivedStateCheck = mapState(state);
       if (!shallowEqual(derivedStateCheck, derivedState)) {
         console.warn(
           'Your mapState function returns a different value ' +

--- a/src/create.ts
+++ b/src/create.ts
@@ -65,19 +65,13 @@ export function create<
    */
   function useMappedState<TResult>(
     mapState: (state: TState) => TResult,
-    shouldMemoize: Boolean = true,
   ): TResult {
     const store = useContext(StoreContext);
     if (!store) {
       throw new MissingProviderError();
     }
 
-    const memoizedMapState = useMemo(() => {
-      if (shouldMemoize) {
-        return memoize(mapState);
-      }
-      return mapState;
-    }, [mapState, shouldMemoize]);
+    const memoizedMapState = useMemo(() => memoize(mapState), [mapState]);
 
     const state = store.getState();
     const derivedState = memoizedMapState(state);


### PR DESCRIPTION
This PR is based on https://github.com/facebookincubator/redux-react-hook/pull/38 (let's merge it!).

This is more of a suggestion rather than a final pull request. The idea is to return not the state value from the hook but an actual mappedState from the global state so it's not stale even while the component is rebasing its state. Right now I don't see why calling mapState directly on store.getState would be a problem but I'm not 100% sure. We can also avoid extra renders to if the mapState function is changed but the actual mappedState remains the same and synchronous state updates are handled correctly. A problem I see is that calling a mapState on every render might be a problem if the mapState is expensive and not memoized so I decided to add a development-only warning that the function should be memoized.

I've also added a test for a state/props mismatch.

If the approach is fine a can try some benchmarking mentioned in https://github.com/facebookincubator/redux-react-hook/issues/39.