### PR TITLE
Don't resubscribe if mapState changes

### DIFF
--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -318,6 +318,18 @@ describe('redux-react-hook', () => {
       // 2. Pull data before right before subscribing in useEffect
       expect(mapStateCalls).toBe(1);
     });
+
+    it("doesn't resubscribe if mapState changes", () => {
+      const Component = ({prop}: {prop: any}) => {
+        useMappedState(React.useCallback(() => {}, [prop]));
+        return null;
+      };
+
+      render(<Component prop={1} />);
+      render(<Component prop={2} />);
+
+      expect(store.subscribe).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('useDispatch', () => {

--- a/src/create.ts
+++ b/src/create.ts
@@ -86,8 +86,11 @@ export function create<
     // one when an action is dispatched and call forceUpdate if they are different.
     const lastStateRef = useRef(derivedState);
 
+    const memoizedMapStateRef = useRef(memoizedMapState);
+
     useEffect(() => {
       lastStateRef.current = derivedState;
+      memoizedMapStateRef.current = memoizedMapState;
     });
 
     useEffect(() => {
@@ -102,7 +105,7 @@ export function create<
           return;
         }
 
-        const newDerivedState = memoizedMapState(store.getState());
+        const newDerivedState = memoizedMapStateRef.current(store.getState());
 
         if (!shallowEqual(newDerivedState, lastStateRef.current)) {
           // In TS definitions userReducer's dispatch requires an argument
@@ -123,7 +126,7 @@ export function create<
         didUnsubscribe = true;
         unsubscribe();
       };
-    }, [store, memoizedMapState]);
+    }, [store]);
 
     return derivedState;
   }


### PR DESCRIPTION
I noticed that you closed https://github.com/facebookincubator/redux-react-hook/pull/9 but I think the idea is good and it shouldn't be a problem if ref is assigned in the commit.

I thought that this might help with the stale props problem since the order of subscribers is not altered but this still doesn't help much since a child can mount at any time after parent.