### PR TITLE
add custom dispatch type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,15 +14,16 @@ import {Action, Dispatch, Store} from 'redux';
 export declare function create<
   TState,
   TAction extends Action,
-  TStore extends Store<TState, TAction>
+  TStore extends Store<TState, TAction>,
+  TDispatch = Dispatch<TAction>
 >(): {
   StoreContext: React.Context<TStore | null>;
   useMappedState: <TResult>(mapState: (state: TState) => TResult) => TResult;
-  useDispatch: () => Dispatch<TAction>;
+  useDispatch: () => TDispatch
 };
 
 export declare const StoreContext: Context<any>;
-export declare const useDispatch: () => Dispatch<any>;
+export declare const useDispatch: <TDispatch = Dispatch<any>>() => TDispatch;
 
 /**
  * Your passed in mapState function should be memoized with useCallback to avoid


### PR DESCRIPTION
In order to inject my custom dispatch type. 
For example i'm using rematch, and the type of rematch dispatch is not the same as redux dispatch.

```
import { init, RematchRootState } from '@rematch/core'
import { useDispatch } from 'redux-react-hook'

export const store = init({
    models
})

export type Store = typeof store
export type IDispatch = typeof store.dispatc

const dispatch = useDispatch<IDispatch>()

// so that i can enable autocomplete of dispatch
dispatch.app.updateSomething({})
```