### PR TITLE
Fix memoize: save argument only if function does not throw

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -33,8 +33,8 @@ function memoizeSingleArg<AT, RT>(fn: (arg: AT) => RT): (arg: AT) => RT {
 
   return (arg: AT) => {
     if (prevArg !== arg) {
-      prevArg = arg;
       value = fn(arg);
+      prevArg = arg;
     }
     return value;
   };


### PR DESCRIPTION
Before, if by any chance, the `fn` function was to throw, the argument would have been saved into `prevArg`, resulting in returning `value` from the previous call if it was to be called again with the same argument after that.

Side note, I'm not sure if worth fixing it, but if `arg` is `undefined` on the first call, then if will match the initial `prevArg` and directly return `value` (which is also `undefined`). I don't think anything is preventing users from having an initial `undefined` state, might not happen a lot though. One easy way to fix it would be to create whatever object and assigning to `let prevArg: AT = initialPrevArg;` so that the strict equality can never yield `true` on the first call.