### PR TITLE
Init prevArg with an empty object

### DIFF
--- a/src/__tests__/index-test.tsx
+++ b/src/__tests__/index-test.tsx
@@ -513,6 +513,29 @@ describe('redux-react-hook', () => {
       expect(getText()).toBe('constant 3');
     });
   });
+
+  describe('memoize', () => {
+    it('should not skip initial call even if initial state is undefined', () => {
+      const store = createReduxStore(() => {});
+
+      const mapState = (s: number | undefined) => s || 'empty';
+      const Component = () => {
+        const bar = useMappedState(mapState);
+        return <div>{bar}</div>;
+      };
+
+      act(() => {
+        ReactDOM.render(
+          <StoreContext.Provider value={store}>
+            <Component />
+          </StoreContext.Provider>,
+          reactRoot,
+        );
+      });
+
+      expect(getText()).toBe('empty');
+    });
+  });
 });
 
 function suppressActError(fn: () => void) {

--- a/src/create.ts
+++ b/src/create.ts
@@ -27,9 +27,14 @@ class MissingProviderError extends Error {
   }
 }
 
+// Init `prevArg` with a local object to ensure the first non-equality check
+// with `arg` always yield `true`, resulting in correctly calling `fn` and
+// assigning `arg` to `prevArg`.
+const initialPrevArg = {};
+
 function memoizeSingleArg<AT, RT>(fn: (arg: AT) => RT): (arg: AT) => RT {
   let value: RT;
-  let prevArg: AT;
+  let prevArg: AT | typeof initialPrevArg = initialPrevArg;
 
   return (arg: AT) => {
     if (prevArg !== arg) {


### PR DESCRIPTION
As mentioned in #94 , this will prevent issues if the initial Redux state is `undefined`, which would result in `prevArg === arg`, skipping the first call to `fn`.